### PR TITLE
Display joined missions

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,11 +1,30 @@
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { member } from '../redux/missions/missionsSlice';
+import '../styles/Missions.css';
 
-function Missions({ name, description }) {
+function Missions({
+  name, description, id, activeMember,
+}) {
+  const dispatch = useDispatch();
   return (
     <tr className="missionRow">
       <td>{name}</td>
       <td>{description}</td>
-      <td>Status</td>
+      <td>
+        <p className={activeMember ? 'activeMember status' : 'notActive status'}>{activeMember ? 'ACTIVE MEMBER' : 'NOT A MEMBER'}</p>
+      </td>
+      <td>
+        <button
+          type="button"
+          className={activeMember ? 'leaveBtn status' : 'joinBtn status'}
+          onClick={() => {
+            dispatch(member(id));
+          }}
+        >
+          {activeMember ? 'Leave Mission' : 'Join Mission'}
+        </button>
+      </td>
     </tr>
   );
 }
@@ -13,6 +32,8 @@ function Missions({ name, description }) {
 Missions.propTypes = {
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  activeMember: PropTypes.bool.isRequired,
 };
 
 export default Missions;

--- a/src/components/MissionsList.js
+++ b/src/components/MissionsList.js
@@ -9,9 +9,9 @@ function MissionsList() {
   const { missions } = useSelector((state) => state.missions);
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(fetchMissions());
+    if (missions.length === 0) dispatch(fetchMissions());
   }, []);
-  console.log(missions);
+
   return (
     <table className="table">
       <thead className="tableHeader">
@@ -25,8 +25,10 @@ function MissionsList() {
         {missions.map((mission) => (
           <Missions
             key={mission.mission_id}
+            id={mission.mission_id}
             name={mission.mission_name}
             description={mission.description}
+            activeMember={mission.activeMember || false}
           />
         ))}
       </tbody>

--- a/src/components/MyProfile.js
+++ b/src/components/MyProfile.js
@@ -2,15 +2,19 @@ import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import '../styles/myProfile.css';
 import { fetchRocketsData } from '../redux/rockets/rocketsSlice';
+import { fetchMissions } from '../redux/missions/missionsSlice';
 
 const MyProfile = () => {
   const dispatch = useDispatch();
   const [loaded, setLoaded] = useState(false);
   const rocketsData = useSelector((state) => state.rockets.rocketsData);
   const reservedRockets = rocketsData.filter((rocket) => rocket.reserved);
+  const { missions } = useSelector((state) => state.missions);
+  const activeMissions = missions.filter((active) => active.activeMember);
 
   useEffect(() => {
     if (rocketsData.length === 0) {
+      dispatch(fetchMissions());
       dispatch(fetchRocketsData()).then(() => setLoaded(true));
     } else {
       setLoaded(true);
@@ -23,8 +27,17 @@ const MyProfile = () => {
 
   return (
     <section className="myProfile">
-      <div>
-        <h3>My Missions</h3>
+      <div style={{ textAlign: 'left' }}>
+        <h3 style={{ marginBottom: '10px' }}>My Missions</h3>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <tbody>
+            {activeMissions.map((missions) => (
+              <tr key={missions.mission_id}>
+                <td style={{ border: '1px solid #dedede', padding: '23px', backgroundColor: 'white' }}>{missions.mission_name}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
       <div style={{ textAlign: 'left' }}>
         <h3 style={{ marginBottom: '10px' }}>My Rockets</h3>

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -5,6 +5,7 @@ const initialState = {
   isLoading: false,
   missions: [],
   error: undefined,
+  joined: false,
 };
 
 const fetchMissions = createAsyncThunk('missions/fetchMissions', async () => {
@@ -21,7 +22,14 @@ const fetchMissions = createAsyncThunk('missions/fetchMissions', async () => {
 const missionsSlice = createSlice({
   name: 'missions',
   initialState,
-  reducers: {},
+  reducers: {
+    member: (state, action) => {
+      const missionId = action.payload;
+      state.missions = state.missions.map((mission) => (mission.mission_id === missionId
+        ? { ...mission, activeMember: !mission?.activeMember ?? true }
+        : mission));
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(fetchMissions.pending, (state) => {
@@ -41,3 +49,4 @@ const missionsSlice = createSlice({
 
 export default missionsSlice.reducer;
 export { fetchMissions };
+export const { member } = missionsSlice.actions;

--- a/src/styles/Missions.css
+++ b/src/styles/Missions.css
@@ -1,0 +1,30 @@
+.status {
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  margin: 0 1rem;
+}
+
+.leaveBtn {
+  color: red;
+  border: 1px solid red;
+  min-width: 135px;
+}
+
+.joinBtn {
+  color: #6c757c;
+  border: 1px solid #6c757c;
+  min-width: 135px;
+}
+
+.notActive {
+  min-width: 135px;
+  color: #fff;
+  background-color: #6c757c;
+  border-radius: 0.5rem;
+}
+
+.activeMember {
+  min-width: 145px;
+  color: #fff;
+  background-color: #18a3b9;
+}

--- a/src/styles/myProfile.css
+++ b/src/styles/myProfile.css
@@ -5,4 +5,5 @@
   margin: 0 auto;
   text-align: center;
   font-size: 1.5rem;
+  gap: 1rem;
 }


### PR DESCRIPTION
This pull request adds the feature to render a list of all joined missions on the `MyProfile` page. The list is filtered using `filter()`. 

## General Requirements
- [x] No linter errors found.
- [x] Correct usage of Gitflow.
- [x] Work has been documented in a professional manner.

## HTML/CSS Requirements
- [x] Follow the list of best practices for HTML & CSS.

## JavaScript Requirements
- [x] Follow the list of best practices for JavaScript.

## Changes Made
1. Create a new module to handle the display of reserved rockets on the `MyProfile` page.
2. Implement the filter function to display only the reserved rockets.
3. Utilize local storage to persist data on page reload.
4. Ensure the code is written according to best HTML, CSS, and JavaScript practices.


> Please @CesarHerr  review this pull request at your earliest convenience. I would greatly appreciate your feedback and suggestions for improvements.

Thank you!
Greetings, @CesarHerr 

[MissionsMyProfileJoined.webm](https://github.com/ClaudiaRojasSoto/Space_Travelers/assets/111262493/1834359a-b706-41aa-ab4f-0ad0dabc0771)

